### PR TITLE
CASA based parallactic angle computation

### DIFF
--- a/plumber/parang_finder.py
+++ b/plumber/parang_finder.py
@@ -6,6 +6,7 @@ import os
 from astroplan.constraints import observability_table
 import click
 import numpy as np
+from math import sin, cos, atan2, pi
 
 import astropy.units as u
 import matplotlib.pyplot as plt
@@ -52,8 +53,8 @@ class parallctic_angle(mset):
         super().__init__()
     def __init__(self) -> None:
         parallctic_angle = []
-        hour_angle
-        observatory_name- ""
+        hour_angle = []
+        observatory_name = "VLA"
         observatory_latitude = ""
         observatory_longitude = ""
         source_dec = ""
@@ -72,7 +73,7 @@ class parallctic_angle(mset):
         #   thus:
         #   tan(eta) = cos(lat)*sin(HA) / (sin(lat)*cos(dec)-cos(lat)*sin(dec)*cos(HA))
         """
-        z = zeros(
+        z = np.zeros(
             (1), dtype={'names': ['parangle', 'slope'], 'formats': ['f8', 'i4']})
         slope = 1.0
         eta = atan2(cos(lat)*sin(HA), (sin(lat) *
@@ -91,7 +92,7 @@ class parallctic_angle(mset):
         me.doframe(me.observatory(observatory))
         tm = me.epoch('UTC', str(time)+'s')
         last = me.measure(tm, 'LAST')['m0']['value']
-        last -= floor(last)
+        last -= np.floor(last)
         lst = qa.convert(str(last)+'d', 'rad')
 
         ha = lst['value']-ra

--- a/plumber/parang_finder.py
+++ b/plumber/parang_finder.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
+import logging
+from _typeshed import Self
 import os
+from astroplan.constraints import observability_table
 import click
 import numpy as np
 
@@ -12,14 +15,17 @@ from astropy.time import Time
 from astropy.coordinates import SkyCoord
 from astroplan import Observer
 
-from casatools import msmetadata
+from casatools import msmetadata, measures, quanta
 msmd = msmetadata()
+qa = quanta()
+me = measures()
 
-import logging
 
 # Add colours for warnings and errors
-logging.addLevelName(logging.WARNING, "\033[1;31m%s\033[1;0m" % logging.getLevelName(logging.WARNING))
-logging.addLevelName(logging.ERROR, "\033[1;41m%s\033[1;0m" % logging.getLevelName(logging.ERROR))
+logging.addLevelName(
+    logging.WARNING, "\033[1;31m%s\033[1;0m" % logging.getLevelName(logging.WARNING))
+logging.addLevelName(
+    logging.ERROR, "\033[1;41m%s\033[1;0m" % logging.getLevelName(logging.ERROR))
 
 logging.basicConfig(
     level=logging.INFO,
@@ -33,12 +39,66 @@ logging.basicConfig(
 logger = logging.getLogger()
 
 ctx = dict(help_option_names=['-h', '--help'])
-@click.command(context_settings = ctx)
+
+
+@click.command(context_settings=ctx)
 @click.argument('MS', type=click.Path(exists=True))
 @click.option('--field', type=str, default=None,
               help='Name of field to consider, must match exactly the name in the MS. '
               'If this is not specified, will use the first field with the '
               'TARGET intent.')
+class parallctic_angle(mset):
+    def __init__(self) -> None:
+        super().__init__()
+    def __init__(self) -> None:
+        parallctic_angle = []
+        hour_angle
+        observatory_name- ""
+        observatory_latitude = ""
+        observatory_longitude = ""
+        source_dec = ""
+        source_times = []
+        scan_times = []
+    def parangle(HA, lat, dec):
+        """
+        #Function to calcualte the parallactic angle.
+        #   Equations from:
+        #   "A treatise on spherical astronomy" By Sir Robert Stawell Ball
+        #   (p. 91, as viewed on Google Books)
+        #   sin(eta)*sin(z) = cos(lat)*sin(HA)
+        #   cos(eta)*sin(z) = sin(lat)*cos(dec) - cos(lat)*sin(dec)*cos(HA)
+        #   Where eta is the parallactic angle, z is the zenith angle, lat is the
+        #   observer's latitude, dec is the declination, and HA is the hour angle.
+        #   thus:
+        #   tan(eta) = cos(lat)*sin(HA) / (sin(lat)*cos(dec)-cos(lat)*sin(dec)*cos(HA))
+        """
+        z = zeros(
+            (1), dtype={'names': ['parangle', 'slope'], 'formats': ['f8', 'i4']})
+        slope = 1.0
+        eta = atan2(cos(lat)*sin(HA), (sin(lat) *
+                                          cos(dec)-cos(lat)*sin(dec)*cos(HA)))
+        if(eta < 0):
+            slope = -1.0
+            eta += 2.0*pi
+        z['parangle'] = eta
+        z['slope'] = slope
+
+        return z
+
+    def hourangle(ra, dec, time, timeunit='s', observatory='VLA'):
+        """#Function to compute the hourangle of a source at a given time, given an observatory name
+        This function uses the measures tool to compute the epoch and the corresponding position"""
+        me.doframe(me.observatory(observatory))
+        tm = me.epoch('UTC', str(time)+'s')
+        last = me.measure(tm, 'LAST')['m0']['value']
+        last -= floor(last)
+        lst = qa.convert(str(last)+'d', 'rad')
+
+        ha = lst['value']-ra
+
+        return ha
+
+
 def main(ms, field):
     """
     Helper script to determine the range of parallactic angles in an input MS.
@@ -56,24 +116,28 @@ def main(ms, field):
                      telescope_pos['m2']['value']]
 
     logger.info(f"Telescope {telescope_name[0]} is at co-ordinates "
-          f"{telescope_pos[0]:.2f} deg, "
-          f"{telescope_pos[1]:.2f} deg, "
-          f"{telescope_pos[2]:.2f} m")
-    
+                f"{telescope_pos[0]:.2f} deg, "
+                f"{telescope_pos[1]:.2f} deg, "
+                f"{telescope_pos[2]:.2f} m")
+
     field_names = msmd.fieldnames()
     target_fields = msmd.fieldsforintent('TARGET', asnames=True)
 
     if len(field_names) == 0:
-        raise ValueError("No fields found in input MS. Please check your inputs.")
+        raise ValueError(
+            "No fields found in input MS. Please check your inputs.")
 
     if field is None:
         if len(target_fields) == 0:
-            logger.warning(f'No fields found with intent TARGET. Using field 0 {field_names[0]}')
-            logger.warning('If this is not desired, pass in --field on the command line.')
+            logger.warning(
+                f'No fields found with intent TARGET. Using field 0 {field_names[0]}')
+            logger.warning(
+                'If this is not desired, pass in --field on the command line.')
             field = field_names[0]
 
         elif len(target_fields) > 1:
-            logger.warning(f'Multiple fields found with intent TARGET. Using the first one {target_fields[0]}')
+            logger.warning(
+                f'Multiple fields found with intent TARGET. Using the first one {target_fields[0]}')
             field = target_fields[0]
 
         elif len(target_fields) == 1:
@@ -84,20 +148,20 @@ def main(ms, field):
         if field not in field_names:
             outmsg = f"Input field {field} not found in MS. Available fields are {','.join(field_names)}"
             raise ValueError(outmsg)
-        
+
         logger.info(f"Using field {field}")
 
     # CASA likes to store the time as mjd seconds
     times = msmd.timesforfield(msmd.fieldsforname(field)[0])
     times = Time(times/(3600.*24), format='mjd')
 
-
     ph_centre = msmd.phasecenter(msmd.fieldsforname(field)[0])
-    ph_centre = SkyCoord(ph_centre['m0']['value']*u.rad, ph_centre['m1']['value']*u.rad, unit='radian')
+    ph_centre = SkyCoord(
+        ph_centre['m0']['value']*u.rad, ph_centre['m1']['value']*u.rad, unit='radian')
     logger.info(f"Co-ordinates of source are {ph_centre.to_string('hmsdms')}")
 
-    obs = Observer(longitude = telescope_pos[0]*u.deg, latitude=telescope_pos[1]*u.deg,
-                    elevation = telescope_pos[2]*u.m, name=telescope_name[0], timezone='Etc/GMT0')
+    obs = Observer(longitude=telescope_pos[0]*u.deg, latitude=telescope_pos[1]*u.deg,
+                   elevation=telescope_pos[2]*u.m, name=telescope_name[0], timezone='Etc/GMT0')
 
     parangs = np.rad2deg(obs.parallactic_angle(times, ph_centre))
 
@@ -108,7 +172,6 @@ def main(ms, field):
     logger.info(f"First parallactic angle is : {parang_beg:.2f}")
     logger.info(f"Middle parallactic angle is : {parang_mid:.2f}")
     logger.info(f"Last parallactic angle is : {parang_end:.2f}")
-
 
     plt.style.use('seaborn-poster')
 

--- a/plumber/plumber.py
+++ b/plumber/plumber.py
@@ -3,6 +3,7 @@
 import click
 from plumber.image import parse_image
 from plumber.zernike import get_zcoeffs, zernikeBeam
+from plumber.parang_finder import parallctic_angle
 
 import logging
 

--- a/plumber/plumber.py
+++ b/plumber/plumber.py
@@ -3,7 +3,7 @@
 import click
 from plumber.image import parse_image
 from plumber.zernike import get_zcoeffs, zernikeBeam
-from plumber.parang_finder import parallctic_angle
+#from plumber.parang_finder import parallctic_angle
 
 import logging
 

--- a/plumber/tests/test_sky.py
+++ b/plumber/tests/test_sky.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from plumber.sky import ParallacticAngle
+import numpy as np
+
+def test_parang_casa(input_ms='../../plumber-data/measurement_sets/J1939-6342_MeerKAT_1400MHz.ms'):
+    parang_casa = ParallacticAngle(ms=input_ms, use_astropy=False)
+    print(parang_casa.parangs[0])
+    print(parang_casa.parangs[-1])
+
+    assert np.allclose(parang_casa.parangs[0], 262.576893)
+    assert np.allclose(parang_casa.parangs[-1], 263.558544)
+
+def test_parang_astropy(input_ms='../../plumber-data/measurement_sets/J1939-6342_MeerKAT_1400MHz.ms'):
+    parang_astro = ParallacticAngle(ms=input_ms, use_astropy=True)
+    print(parang_astro.parangs[0])
+    print(parang_astro.parangs[-1])
+
+    assert np.allclose(parang_astro.parangs[0], -97.4202206)
+    assert np.allclose(parang_astro.parangs[-1], -96.4385573)


### PR DESCRIPTION
As per #4 - the calculations of parallactic angle from within CASA and within `astroplan.Observer` are different. This PR incorporates both methods into the `plumber.sky.ParallacticAngle` class, either of which can be accessed with a flag. 

The parallactic angle calculated via CASA is `2*pi` rad different from that calculated via `astroplan.Observer`. 