### PR TITLE
Fixes #11

### DIFF
--- a/plumber/sky.py
+++ b/plumber/sky.py
@@ -82,10 +82,10 @@ class ParallacticAngle():
                     self.telescope_pos['m2']['value']
         ]
 
-        logger.info(f"Telescope {self.telescope_name[0]} is at co-ordinates "
+        logger.info(f"Telescope {self.telescope_name} is at co-ordinates "
                 f"{np.rad2deg(self.telescope_pos[0]):.2f} deg, "
                 f"{np.rad2deg(self.telescope_pos[1]):.2f} deg, "
-                f"{np.rad2deg(self.telescope_pos[2]):.2f} m")
+                f"{self.telescope_pos[2]:.2f} m")
 
         self.field_names = msmd.fieldnames()
         self.target_fields = msmd.fieldsforintent('TARGET', asnames=True)


### PR DESCRIPTION
Formatting errors in printing the telescope name and position.
`np.rad2deg` was accidentally called on the telescope Z co-ordinate,
which is in metres.

Similarly only the first letter of the telescope name was being printed
instead of the entire string.

Both these issues have been fixed.