### PR TITLE
Fixed typo in sky.py line 73: telesocpe --> telescope 

### DIFF
--- a/plumber/sky.py
+++ b/plumber/sky.py
@@ -70,7 +70,7 @@ class ParallacticAngle():
 
         if len(self.telescope_name) > 1:
             logger.warning(f"Multiple observatory names found : {','.join(self.telescope_name)}. "
-                           f"Using the first one, {self.telesocpe_name[0]}")
+                           f"Using the first one, {self.telescope_name[0]}")
 
         self.telescope_name = self.telescope_name[0]
         self.telescope_pos = msmd.observatoryposition()


### PR DESCRIPTION
For MSs having more than one telescope names, parang_finder throws an AttributeError because of this typo. Fixed it and verified the corrected version. Two screenshots attached: first one showing the issue, second one shows the corrected output.
![attribute_error](https://user-images.githubusercontent.com/59552517/159075231-8b74f199-866a-4fe4-9b06-51e3231ff1d7.png)
![attribute_fixed](https://user-images.githubusercontent.com/59552517/159075249-0241eb31-ffb6-4a73-b393-c0e680a6cd14.png)

