### PR TITLE
Force frequency selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 *.pyc
 *.log
+flycheck*

--- a/plumber/scripts/plumber.py
+++ b/plumber/scripts/plumber.py
@@ -3,6 +3,8 @@
 import click
 from plumber.image import parse_image
 from plumber.zernike import get_zcoeffs, zernikeBeam
+
+import astropy.units as u
 #from plumber.parang_finder import parallctic_angle
 
 import logging
@@ -66,12 +68,13 @@ def main(imagename, csv, padding, circular, dish_dia, frequency, stokesi, linear
     imsize, imfreq, is_stokes_cube = parse_image(imagename)
 
     if frequency is not None:
-        imfreq = [frequency*1e6,]
-
-    zdflist, zfreqlist, nstokes = get_zcoeffs(csv, imfreq)
-
-    logger.info(f"Image is at {imfreq[0].value/1e6:.2f} MHz. Model PB will be generated at {zfreqlist[0]:.2f} MHz")
-    logger.warn(f"The above frequency is the first channel frequency if the input image is a spectral cube")
+        frequency = [frequency*u.MHz,]
+        zdflist, zfreqlist, nstokes = get_zcoeffs(csv, frequency)
+        logger.info(f"Image is at {imfreq[0].value/1e6:.2f} MHz. Forcing model PB to be generated at {zfreqlist[0]:.2f} MHz")
+    else:
+        zdflist, zfreqlist, nstokes = get_zcoeffs(csv, imfreq)
+        logger.info(f"Image is at {imfreq[0].value/1e6:.2f} MHz. Model PB will be generated at {zfreqlist[0]:.2f} MHz")
+    #logger.warn(f"The above frequency is the first channel frequency if the input image is a spectral cube")
 
     zb = zernikeBeam()
 

--- a/plumber/scripts/plumber.py
+++ b/plumber/scripts/plumber.py
@@ -66,7 +66,7 @@ def main(imagename, csv, padding, circular, dish_dia, frequency, stokesi, linear
     imsize, imfreq, is_stokes_cube = parse_image(imagename)
 
     if frequency is not None:
-        imfreq = frequency*1e6
+        imfreq = [frequency*1e6,]
 
     zdflist, zfreqlist, nstokes = get_zcoeffs(csv, imfreq)
 

--- a/plumber/scripts/plumber.py
+++ b/plumber/scripts/plumber.py
@@ -27,14 +27,15 @@ ctx = dict(help_option_names=['-h', '--help'])
 @click.argument('imagename', type=click.Path(exists=True))
 @click.argument('CSV', type=click.File())
 @click.option('-a', '--padding', type=int, default=8, help='Padding factor for aperture, affects smoothness of output beam', show_default=True)
-@click.option('-d', '--dish_dia', type=float, default=None, help='Diameter of the antenna dish. If not one of VLA, ALMA, MeerKAT or GMRT, must be specified.')
-@click.option('-l', '--linear', is_flag=True, help='Specifies if the telescope has linear feeds. If not one of VLA, ALMA, MeerKAT or GMRT, must be specified')
 @click.option('-c', '--circular', is_flag=True, help='Specifies if the telescope has circular feeds. If not one of VLA, ALMA, MeerKAT or GMRT, must be specified')
+@click.option('-d', '--dish_dia', type=float, default=None, help='Diameter of the antenna dish. If not one of VLA, ALMA, MeerKAT or GMRT, must be specified.')
+@click.option('-f', '--frequency', type=float, help='Force a frequency at which to generate the beam (in MHz). Plumber will choose the nearest available frequency from the CSV file.')
 @click.option('-I', '--stokesI', is_flag=True, help='Only generate the Stokes I beam, not the full Stokes beams')
-@click.option('-P', '--parallel', is_flag=True, help='Use parallel processing (no MPI) to speed things up')
+@click.option('-l', '--linear', is_flag=True, help='Specifies if the telescope has linear feeds. If not one of VLA, ALMA, MeerKAT or GMRT, must be specified')
 @click.option('-p', '--parang', type=float, default=0, help='Parallactic angle at which to generate the PB', show_default=True)
+@click.option('-P', '--parallel', is_flag=True, help='Use parallel processing (no MPI) to speed things up')
 @click.option('--parang-file', type=click.Path(exists=True), help='Pass a file containing a list of parallactic angles and weights')
-def main(imagename, csv, padding, dish_dia, linear, circular, stokesi, parallel, parang, parang_file):
+def main(imagename, csv, padding, circular, dish_dia, frequency, stokesi, linear, parang, parang, parang_file):
     """
     Given the input image and the coefficient CSV file, generate the full Stokes
     primary beam at the image centre frequency. If the input is a cube, a
@@ -63,6 +64,10 @@ def main(imagename, csv, padding, dish_dia, linear, circular, stokesi, parallel,
     #    raise ValueError(f"Either pass in a single PA or two values of PA. Currently set to {parang}")
 
     imsize, imfreq, is_stokes_cube = parse_image(imagename)
+
+    if frequency is not None:
+        imfreq = frequency*1e6
+
     zdflist, zfreqlist, nstokes = get_zcoeffs(csv, imfreq)
 
     logger.info(f"Image is at {imfreq[0].value/1e6:.2f} MHz. Model PB will be generated at {zfreqlist[0]:.2f} MHz")

--- a/plumber/scripts/plumber.py
+++ b/plumber/scripts/plumber.py
@@ -35,7 +35,7 @@ ctx = dict(help_option_names=['-h', '--help'])
 @click.option('-p', '--parang', type=float, default=0, help='Parallactic angle at which to generate the PB', show_default=True)
 @click.option('-P', '--parallel', is_flag=True, help='Use parallel processing (no MPI) to speed things up')
 @click.option('--parang-file', type=click.Path(exists=True), help='Pass a file containing a list of parallactic angles and weights')
-def main(imagename, csv, padding, circular, dish_dia, frequency, stokesi, linear, parang, parang, parang_file):
+def main(imagename, csv, padding, circular, dish_dia, frequency, stokesi, linear, parang, parallel, parang_file):
     """
     Given the input image and the coefficient CSV file, generate the full Stokes
     primary beam at the image centre frequency. If the input is a cube, a

--- a/plumber/zernike.py
+++ b/plumber/zernike.py
@@ -30,7 +30,7 @@ from casatools import image
 ia = image()
 
 
-def get_zcoeffs(csv: str, imfreq: float) -> Union[pd.Dataframe, float, int]:
+def get_zcoeffs(csv: str, imfreq: list) -> Union[pd.Dataframe, float, int]:
     """
     Given the input frequency of the image, returns the Pandas dataframe with
     the coefficients corresponding to the input frequency. The frequencies in
@@ -38,7 +38,7 @@ def get_zcoeffs(csv: str, imfreq: float) -> Union[pd.Dataframe, float, int]:
 
     Inputs:
     csv         Input CSV filename, string
-    imfreq      Image frequency in MHz, float
+    imfreq      Image frequency in MHz, list of floats (astropy.units)
 
     Returns:
     zdf         Dataframe containing the subset of the CSV file which is closest


### PR DESCRIPTION
This PR introduces a flag to `plumber` to allow for forcing generation of a PB at a particular frequency. This is useful for situations where a single reference image is available, but multiple PBs are required to be generated. 

The frequency passed in with the `--frequency` parameter is still compared to the input CSV, and the nearest available frequency is selected. However this flag allows the frequency of the image and the frequency of the generated PB to be decoupled.